### PR TITLE
Make venv cache key unique per matrix combination

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     
-    - name: Set up Python 3.x
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.8'
     
     - name: Install Poetry
       uses: dschep/install-poetry-action@v1.2
@@ -34,7 +34,7 @@ jobs:
       id: cache
       with:
         path: .venv
-        key: gustavgrad-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
+        key: gustavgrad-venv-${{ runner.os }}-${{ runner.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
     - name: Install Dependencies
       run: poetry install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,11 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: [3.7, 3.8]
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
@@ -36,7 +35,7 @@ jobs:
       id: cache
       with:
         path: .venv
-        key: gustavgrad-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
+        key: gustavgrad-venv-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
     - name: Install Dependencies
       run: poetry install


### PR DESCRIPTION
Previously the cache key was the same regardless
of matrix os and python version, leading to all
tests being ran with the same venv.