### PR TITLE
Add no_grad context manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
+/dist
 .vscode
 *.env
 .mypy_cache

--- a/examples/fizzbuzz.py
+++ b/examples/fizzbuzz.py
@@ -103,8 +103,9 @@ for _ in progress_bar:
         optimizer.step(mlp)
 
     # Evaluate on validation set after each epoch
-    val_pred = mlp.predict(X_val)
-    val_accuracy = accuracy(val_pred, y_val)
+    with mlp.no_grad():
+        val_pred = mlp.predict(X_val)
+        val_accuracy = accuracy(val_pred, y_val)
     progress_bar.set_description(
         f"Validation set accuracy: {val_accuracy:.3f}"
     )

--- a/src/gustavgrad/module.py
+++ b/src/gustavgrad/module.py
@@ -1,4 +1,5 @@
 import inspect
+from contextlib import ExitStack, contextmanager
 from typing import Iterator
 
 import numpy as np
@@ -27,3 +28,10 @@ class Module:
     def zero_grad(self) -> None:
         for parameter in self.parameters():
             parameter.zero_grad()
+
+    @contextmanager
+    def no_grad(self) -> Iterator[None]:
+        with ExitStack() as stack:
+            for parameter in self.parameters():
+                stack.enter_context(parameter.no_grad())
+            yield

--- a/src/gustavgrad/tensor.py
+++ b/src/gustavgrad/tensor.py
@@ -1,9 +1,11 @@
 """
 Tensor Class and affiliated functions
 """
+from contextlib import contextmanager
 from typing import (
     Any,
     Callable,
+    Iterator,
     List,
     NamedTuple,
     Optional,
@@ -124,6 +126,15 @@ class Tensor:
 
         for tensor, grad_fn in self.depends_on:
             tensor.backward(grad_fn(grad))
+
+    @contextmanager
+    def no_grad(self) -> Iterator[None]:
+        original_requires_grad = self.requires_grad
+        self._requires_grad = False
+        try:
+            yield
+        finally:
+            self._requires_grad = original_requires_grad
 
     def __add__(self, other: Tensorable) -> "Tensor":
         return _add(self, ensure_tensor(other))

--- a/src/gustavgrad/tensor.py
+++ b/src/gustavgrad/tensor.py
@@ -74,7 +74,7 @@ class Tensor:
         # Private, see self.data() property for explanation
         # TODO: Perhaps cast to float?
         self._data = ensure_array(data)
-        self.requires_grad = requires_grad
+        self._requires_grad = requires_grad
         self.depends_on = depends_on
         self.grad: Optional["Tensor"] = None
         self.shape: tuple = self._data.shape
@@ -88,6 +88,10 @@ class Tensor:
             + ("\n" if self.data.ndim > 1 else "")
             + f"{self.data}, requires_grad={self.requires_grad})"
         )
+
+    @property
+    def requires_grad(self) -> bool:
+        return self._requires_grad
 
     @property
     def data(self) -> np.ndarray:

--- a/tests/module/test_module.py
+++ b/tests/module/test_module.py
@@ -93,3 +93,26 @@ class TestModule:
         np.testing.assert_allclose(
             model_with_sub_model_and_non_zero_grad.layer2.grad, 0
         )
+
+    def test_no_grad_updates_all_parameter(self, model: Model) -> None:
+        with model.no_grad():
+            assert not any(
+                [param.requires_grad for param in model.parameters()]
+            )
+
+    def test_no_grad_resets_all_parameter(self, model: Model) -> None:
+        with model.no_grad():
+            pass
+        assert all([param.requires_grad for param in model.parameters()])
+
+    def test_grad_intact(self, model_with_non_zero_grad: Model) -> None:
+        initial_grads = [
+            param.grad for param in model_with_non_zero_grad.parameters()
+        ]
+
+        with model_with_non_zero_grad.no_grad():
+            _ = model_with_non_zero_grad.predict(Tensor([[1, 2], [1, 3]]))
+
+        assert [
+            param.grad for param in model_with_non_zero_grad.parameters()
+        ] == initial_grads

--- a/tests/tensor/operation/test_add.py
+++ b/tests/tensor/operation/test_add.py
@@ -4,19 +4,38 @@ from gustavgrad import Tensor
 
 
 class TestTensorAdd:
-    def test_simple_add(self) -> None:
+    def test_simple_add_result(self) -> None:
         t1 = Tensor([1, 2, 3], requires_grad=True)
         t2 = Tensor([4, 5, 6], requires_grad=True)
-
         t3 = t1 + t2
 
         assert t3.data.tolist() == [5, 7, 9]
         assert t3.requires_grad
 
+    def test_simple_add_backward(self) -> None:
+        t1 = Tensor([1, 2, 3], requires_grad=True)
+        t2 = Tensor([4, 5, 6], requires_grad=True)
+        t3 = t1 + t2
         t3.backward(np.asarray([1.0, 1.0, 1.0]))
 
         assert t1.grad.tolist() == [1.0, 1.0, 1.0]
         assert t2.grad.tolist() == [1.0, 1.0, 1.0]
+
+    def test_add_depends_on_requires_grad_true(self) -> None:
+        t1 = Tensor([1, 2, 3], requires_grad=True)
+        t2 = Tensor([4, 5, 6], requires_grad=True)
+        t3 = t1 + t2
+
+        assert t1 in [dependency.tensor for dependency in t3.depends_on]
+        assert t2 in [dependency.tensor for dependency in t3.depends_on]
+
+    def test_add_depends_on_requires_grad_false(self) -> None:
+        t1 = Tensor([1, 2, 3], requires_grad=True)
+        t2 = Tensor([4, 5, 6], requires_grad=False)
+        t3 = t1 + t2
+
+        assert t1 in [dependency.tensor for dependency in t3.depends_on]
+        assert t2 not in [dependency.tensor for dependency in t3.depends_on]
 
     def test_simple_add_no_grad(self) -> None:
         t1 = Tensor([1, 2, 3])
@@ -27,35 +46,42 @@ class TestTensorAdd:
         assert t3.data.tolist() == [5, 7, 9]
         assert not t3.requires_grad
 
-    def test_scalar_add(self) -> None:
+    def test_scalar_add_result(self) -> None:
         t1 = Tensor([1, 2, 3], requires_grad=True)
-
         t2 = t1 + 1
         assert t2.data.tolist() == [2, 3, 4]
 
+    def test_scalar_add_backward(self) -> None:
+        t1 = Tensor([1, 2, 3], requires_grad=True)
+        t2 = t1 + 1
         t2.backward(np.asarray([1.0, 1.0, 1.0]))
         assert t1.grad.tolist() == [1.0, 1.0, 1.0]
 
-    def test_array_add(self) -> None:
+    def test_array_add_result(self) -> None:
         t1 = Tensor([1, 2, 3], requires_grad=True)
-
         t2 = t1 + np.array([4, 5, 6])
         assert t2.data.tolist() == [5, 7, 9]
 
+    def test_array_add_backward(self) -> None:
+        t1 = Tensor([1, 2, 3], requires_grad=True)
+        t2 = t1 + np.array([4, 5, 6])
         t2.backward(np.asarray([1.0, 1.0, 1.0]))
         assert t1.grad.tolist() == [1.0, 1.0, 1.0]
 
-    def test_scalar_radd(self) -> None:
+    def test_scalar_radd_result(self) -> None:
         t1 = Tensor([1, 2, 3], requires_grad=True)
 
         t2 = 1 + t1
         assert type(t2) is Tensor
         assert t2.data.tolist() == [2, 3, 4]
 
+    def test_scalar_radd_backward(self) -> None:
+        t1 = Tensor([1, 2, 3], requires_grad=True)
+        t2 = 1 + t1
         t2.backward(np.asarray([1.0, 1.0, 1.0]))
         assert t1.grad.tolist() == [1.0, 1.0, 1.0]
 
-    def test_broadcasted_add1(self) -> None:
+    def test_broadcasted_add_extra_dimension(self) -> None:
         """ In this test t2 is broadcasted by adding a dimension and then
         repeating it's values"""
         t1 = Tensor([[1, 2, 3], [4, 5, 6]], requires_grad=True)
@@ -72,7 +98,7 @@ class TestTensorAdd:
         # broadcasted to two places.
         assert t2.grad.tolist() == [2.0, 2.0, 2.0]
 
-    def test_broadcasted_add2(self) -> None:
+    def test_broadcasted_add_same_dimension(self) -> None:
         """ In this test t2 is broadcasted only by repeating it's values"""
         t1 = Tensor([[1, 2, 3], [4, 5, 6]], requires_grad=True)
         t2 = Tensor([[1, 2, 3]], requires_grad=True)
@@ -88,7 +114,7 @@ class TestTensorAdd:
         # broadcasted to two places.
         assert t2.grad.tolist() == [[2.0, 2.0, 2.0]]
 
-    def test_broadcasted_add3(self) -> None:
+    def test_broadcasted_add_inner_dimension(self) -> None:
         """ In this test t2 has shape (3, 1, 2) and is broadcasted across an
         inner dimension"""
         t1 = Tensor(np.ones(shape=(3, 2, 2)), requires_grad=True)


### PR DESCRIPTION
Adds the `no_grad` context manager to `Tensor` and `Module`.

The `no_grad` context manager can be used to temporarily disable gradient computations for a `Tensor` or `Module`. It can be used to speed up computations in situations where `backward` will not be called, such as when evaluating on a test or validation set.
```python
with tensor.no_grad():
    ...
```
```python
with module.no_grad():
    ...
```